### PR TITLE
Changed package name according to documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "extract_nested_eml"
+name = "mattex"
 version = "0.1.0"
 authors = ["horle <horle@users.noreply.github.com>"]
 edition = "2018"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::{env, fs, io, path};
 
 fn help() {
     println!("Usage:");
-    println!(" mattex <eml input file>       Extract mail attachments");
+    println!("  mattex <eml input file>       Extract mail attachments");
 }
 
 fn main() {


### PR DESCRIPTION
The executable was named ```extract_nested_eml``` instead of ```mattex``` as it is documented.